### PR TITLE
chore(ci allow dirty workspace when publishing crates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,4 +30,4 @@ jobs:
           fetch-depth: 1
       - uses: keloran/version-bump@main
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --all-features --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - run: cargo publish --all-features --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --allow-dirty


### PR DESCRIPTION
Include --allow-dirty on the cargo publish step in the CI workflow to
permit publishing even when there are uncommitted changes in the
runner's workspace. This avoids failures caused by transient or
generated files present during automated releases and ensures the
deploy workflow completes without requiring a clean working tree.